### PR TITLE
Adds ability to pass in map of file format options when creating a PailSpec.

### DIFF
--- a/src/main/clojure/clj_pail/core.clj
+++ b/src/main/clojure/clj_pail/core.clj
@@ -1,5 +1,5 @@
 (ns clj-pail.core
-  (:import (com.backtype.hadoop.pail Pail PailSpec PailStructure)))
+  (:import (com.backtype.hadoop.pail Pail PailSpec PailStructure PailFormatFactory)))
 
 
 (defn ^PailSpec spec
@@ -7,7 +7,7 @@
   ([^PailStructure structure]
      (PailSpec. structure))
   ([^PailStructure structure opts]
-     (PailSpec. nil opts structure)))
+     (PailSpec. PailFormatFactory/SEQUENCE_FILE opts structure)))
 
 
 (defn ^Pail pail

--- a/src/main/clojure/clj_pail/core.clj
+++ b/src/main/clojure/clj_pail/core.clj
@@ -1,13 +1,13 @@
 (ns clj-pail.core
-  (:import (com.backtype.hadoop.pail Pail PailSpec PailStructure PailFormatFactory)))
+  (:import (com.backtype.hadoop.pail Pail PailSpec PailStructure)))
 
 
 (defn ^PailSpec spec
   "Builds a PailSpec from a PailStructure."
   ([^PailStructure structure]
      (PailSpec. structure))
-  ([^PailStructure structure opts]
-     (PailSpec. PailFormatFactory/SEQUENCE_FILE opts structure)))
+  ([^PailStructure format structure opts]
+     (PailSpec. format opts structure)))
 
 
 (defn ^Pail pail

--- a/src/main/clojure/clj_pail/core.clj
+++ b/src/main/clojure/clj_pail/core.clj
@@ -4,8 +4,10 @@
 
 (defn ^PailSpec spec
   "Builds a PailSpec from a PailStructure."
-  [^PailStructure structure]
-  (PailSpec. structure))
+  ([^PailStructure structure]
+     (PailSpec. structure))
+  ([^PailStructure structure opts]
+     (PailSpec. nil opts structure)))
 
 
 (defn ^Pail pail

--- a/test/clj_pail/core_test.clj
+++ b/test/clj_pail/core_test.clj
@@ -2,7 +2,7 @@
   (:require [clj-pail.core :as pail]
             [clojure.java.shell :as shell])
   (:use midje.sweet)
-  (:import (com.backtype.hadoop.pail PailSpec PailStructure DefaultPailStructure)
+  (:import (com.backtype.hadoop.pail PailSpec PailStructure DefaultPailStructure SequenceFileFormat)
            (org.apache.hadoop.fs FileSystem Path)
            (org.apache.hadoop.conf Configuration)))
 
@@ -22,7 +22,14 @@
   (let [structure (proxy [PailStructure] [])]
     (fact "creates a PailSpec from a PailStructure"
       (pail/spec structure) => (instance-of PailSpec )
-      (.getStructure (pail/spec structure)) => structure)))
+      (.getStructure (pail/spec structure)) => structure
+      (.getArgs (pail/spec structure)) => nil)
+
+    (fact "create a PailSpec from a PailStructure and options"
+      (let [opts {SequenceFileFormat/CODEC_ARG
+                  SequenceFileFormat/CODEC_ARG_GZIP}]
+        (pail/spec structure opts) => (instance-of PailSpec)
+        (.getArgs (pail/spec structure opts)) => opts))))
 
 
 (let [tmp-path "tmp/test"]

--- a/test/clj_pail/core_test.clj
+++ b/test/clj_pail/core_test.clj
@@ -2,7 +2,7 @@
   (:require [clj-pail.core :as pail]
             [clojure.java.shell :as shell])
   (:use midje.sweet)
-  (:import (com.backtype.hadoop.pail PailSpec PailStructure DefaultPailStructure SequenceFileFormat)
+  (:import (com.backtype.hadoop.pail PailSpec PailStructure DefaultPailStructure SequenceFileFormat PailFormatFactory)
            (org.apache.hadoop.fs FileSystem Path)
            (org.apache.hadoop.conf Configuration)))
 
@@ -28,8 +28,8 @@
     (fact "create a PailSpec from a PailStructure and options"
       (let [opts {SequenceFileFormat/CODEC_ARG
                   SequenceFileFormat/CODEC_ARG_GZIP}]
-        (pail/spec structure opts) => (instance-of PailSpec)
-        (.getArgs (pail/spec structure opts)) => opts))))
+        (pail/spec PailFormatFactory/SEQUENCE_FILE structure opts) => (instance-of PailSpec)
+        (.getArgs (pail/spec PailFormatFactory/SEQUENCE_FILE structure opts)) => opts))))
 
 
 (let [tmp-path "tmp/test"]


### PR DESCRIPTION
By default the Pail file format is Hadoop SequenceFile.
There are three SequenceFileWriters each based on a compression type (none, record, block). The compression codec may also be specified.

This change allows us to pass compression type and compression codec options for Pail to use when creating the underlying SequenceFile.
