### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ Serialization is defined by extending the [`clj-pail.serializer.Serializer`](src
 (defrecord CustomDateSerializer [#^java.text.DateFormat format]
   s/Serializer
   (serialize [this date]
-    (.. (:format this)
+    (.. (get this :format)
       (format date)
       (getBytes)))
 
   (deserialize [this buffer]
-    (.parse (:format this)
+    (.parse (get this :format)
             (String. buffer))))
 ~~~
 


### PR DESCRIPTION
was getting this error with (:format this)
java.lang.ClassCastException: cascalog_pail_avro.avro_pail_structure.AvroPartitioner cannot be cast to clojure.lang.IFn

the explicit (get this :format) works
